### PR TITLE
docs: modernize docs for script-backed gallery; fix gallery generator output

### DIFF
--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,2 +1,10 @@
 ﻿# API: plotting
 ::: fastf1_portfolio.plotting
+
+**Examples**
+```python
+from fastf1_portfolio.plotting import get_team_color, get_compound_color, savefig, apply_style
+apply_style()
+print(get_team_color("Ferrari"))
+print(get_compound_color("Soft"))
+```

--- a/docs/api/session_loader.md
+++ b/docs/api/session_loader.md
@@ -1,2 +1,9 @@
 ﻿# API: session_loader
 ::: fastf1_portfolio.session_loader
+
+**Example**
+```python
+from fastf1_portfolio.session_loader import load_session
+session = load_session(2024, "Monaco", "R", cache=".fastf1-cache")
+print(session.event["EventName"], session.name)
+```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,4 +1,26 @@
 ﻿# How it works
-- **Caching**: FastF1 cache at `.fastf1/` (configurable).
-- **Style**: Centralized Matplotlib styling in `plotting.py`.
-- **Loader**: `load_session(year, gp, session)` for consistent data access.
+
+## Pipeline
+1. **Plot script** in `tools/plots/*.py` loads data (via `session_loader.load_session`), calls a chart
+   function from `src/fastf1_portfolio/charts/*`, and writes:
+   - a **PNG** to `docs/assets/gallery/…`
+   - a **YAML** sidecar with title, code path, and parameters.
+2. **Gallery generator** (`tools/generate_gallery.py`) reads all sidecars and rewrites the card grid
+   between markers in `docs/gallery.md`.
+3. **MkDocs** builds a static site — no live API calls on GitHub Pages.
+
+## Caching
+- FastF1 cache (default `.fastf1-cache/`) speeds up runs; feel free to delete to refresh data.
+- Scripts create the cache directory if missing.
+
+## Consistent look & colors
+- `fastf1_portfolio.plotting` centralizes:
+  - `apply_style`, `savefig`
+  - `get_team_color`, `get_compound_color`, `lighten_color`
+
+## Reproduce a tile
+```bash
+python tools/plots/tyre_strategy.py --year 2025 --event "Italian Grand Prix" --cache .fastf1-cache
+python tools/generate_gallery.py
+mkdocs serve
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,15 @@ High-quality analyses and reusable helpers built on [FastF1](https://docs.fastf1
 
 ```bash
 pip install -e .[dev]
-# Generate Monaco visuals
-python examples/scripts/monaco_2024_qual_bestlaps.py
-python examples/scripts/race_tyre_strategy.py
-python examples/scripts/pace_evolution.py
-python examples/scripts/positions_gained.py
-python examples/scripts/telemetry_compare.py
+# Generate gallery tiles (PNG + YAML sidecar)
+python tools/plots/tyre_strategy.py --year 2025 --event "Italian Grand Prix" --cache .fastf1-cache
+python tools/plots/driver_championship.py --year 2024 --include-sprints --cache .fastf1-cache
+
+# Rebuild the Gallery page from sidecars
+python tools/generate_gallery.py
+
+# Preview the site
+mkdocs serve
 ```
 
 See the **[Gallery](gallery.md)** for the latest visuals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,4 +44,3 @@ nav:
       - Session Loader: api/session_loader.md
       - Plotting: api/plotting.md
       - fastf1_portfolio: reference/fastf1_portfolio.md
-      - Gallery API: api/gallery/index.md

--- a/tools/generate_gallery.py
+++ b/tools/generate_gallery.py
@@ -18,14 +18,7 @@ def load_items() -> list[dict]:
 
 
 def render_gallery(items: list[dict]) -> str:
-    lines = [
-        "# Gallery",
-        "",
-        "Below is a curated set of static visuals. Click any tile to zoom.",
-        "",
-        '<div class="grid cards" markdown>',
-        "",
-    ]
+    lines = ['<div class="grid cards" markdown>', ""]
     for it in items:
         title = it["title"]
         subtitle = it.get("subtitle", "")
@@ -39,7 +32,7 @@ def render_gallery(items: list[dict]) -> str:
             "  ---",
             f"  [![{title}]({img}){{ loading=lazy }}]({img}){{ .glightbox }}",
             f"  _{subtitle}_",
-            "  ",
+            "",
             f"  `Source:` `{code}`  ",
             f"  `Params:` `{ppreview}`",
             "",
@@ -53,7 +46,7 @@ def replace_block(text: str, block: str) -> str:
         pre = text.split(BEGIN, 1)[0]
         post = text.split(END, 1)[1]
         return f"{pre}{BEGIN}\n{block}\n{END}{post}"
-    # If markers are missing, just return the block with markers appended
+    # If markers are missing, append after any existing content
     return f"{text.rstrip()}\n\n{BEGIN}\n{block}\n{END}\n"
 
 


### PR DESCRIPTION
- Home: switch Quickstart to tools/plots + gallery generator
- Gallery: remove duplicate header in auto-generated block
- How it works: document pipeline, caching, and plotting helpers
- API pages: add usage snippets (session_loader, plotting)
- Legacy page: mark examples-based gallery as legacy (removed from nav)
- Generator: emit only card grid (no header) and correct card syntax/indentation