### PR TITLE
Merge Chore/update documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,11 @@
     rev: 24.8.0
     hooks:
       - id: black
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system         # use your current venv (so deps are already installed)
+        pass_filenames: false    # pytest decides what to run; don't pass changed files
+        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -4,33 +4,154 @@
 [![Docs](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/docs.yml/badge.svg)](https://ksherr0.github.io/fastf1_portfolio/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Analyses and reusable helpers built on FastF1 to showcase data storytelling, visuals, and racing insights.
+Analyses and reusable helpers built on [FastF1](https://docs.fastf1.dev/) to showcase race strategy, telemetry, and season-long insights.
 
-## Highlights
-- **Qualifying best-laps** with authentic team colors and data labels
-- **Race tyre strategies** (stint bars by compound)
-- **Telemetry comparisons** (speed trace + optional Δt)
-- **Pace evolution** (lap-by-lap trends)
-- **Positions gained/lost** (race craft at a glance)
+- [CI](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/ci.yml)
+- [Docs (Github Pages)](https://ksherr0.github.io/fastf1_portfolio/)
 
-## Reproduce locally
+## Table of Contents:
+- [Docs overview (Github Pages)](#docs-overview-github-pages)
+- [Requirements](#requirements)
+- [Install](#install)
+- [Pre-checks (what CI runs)](#pre-checks-what-ci-runs)
+- [Generate the plots (CLI)](#generate-the-plots-cli)
+    - [Tyre Strategy](#tyre-strategy)
+    - [DRS Effectiveness](#drs-effectiveness)
+    - [Drivers' championship points](#drivers-championship-points)
+    - [Update the Gallery page](#update-the-gallery-page)
+    - [Where to find outputs](#where-to-find-outputs)
+- [Programmatic usage (quick examples)](#programmatic-usage-quick-examples)
+- [Troubleshooting & tips](#troubleshooting--tips)
 
+## Docs overview (Github Pages)
+If you’re not sure where something lives in the docs, use this map:
+- **Home (Quickstart):** install, run 1-2 plots, rebuild gallery, preview site
+    - https://ksherr0.github.io/fastf1_portfolio/
+- **Gallery:** all pre-rendered visuals; each card shows the script + params used
+    - https://ksherr0.github.io/fastf1_portfolio/gallery/
+- **How it works:** pipeline (plot script → PNG+YAML → gallery generator → MkDocs), caching notes
+    - https://ksherr0.github.io/fastf1_portfolio/how-it-works/
+- **API → Session Loader:** `load_session(year, gp, session, *, cache)`
+    - https://ksherr0.github.io/fastf1_portfolio/api/session_loader/
+- **API → Plotting Helpers:** `apply_style, get_team_color, get_compound_color, savefig`, etc
+    - https://ksherr0.github.io/fastf1_portfolio/api/plotting/
+- **Reference (module index):** top-level functions in `fastf1_portfolio`
+    - https://ksherr0.github.io/fastf1_portfolio/reference/fastf1_portfolio/
+
+## Requirements
+- **Python:** 3.13+
+- Works on all operating systems
+
+## Install
 ```bash
+git clone https://github.com/ksherr0/fastf1_portfolio.git
+cd fastf1_portfolio
+
+python -m venv .venv && source .venv\Scripts\activate  # Linux: .venv/bin/activate
+
+# editable install with dev extras (linters, tests, docs)
 pip install -e .[dev]
-python examples/scripts/monaco_2024_qual_bestlaps.py
-python examples/scripts/race_tyre_strategy.py
-python examples/scripts/pace_evolution.py
-python examples/scripts/positions_gained.py
-python examples/scripts/telemetry_compare.py
 ```
 
-Outputs are saved under `docs/assets/gallery/` and surfaced in **docs/gallery**.
+## Pre-checks (what CI runs)
+Run locally to match CI behavior:
+```bash
+ruff check .
+black --check .
+pytest -q
+```
 
-## Package APIs
+<div style="page-break-after: always"></div>
+
+## Generate the plots (CLI)
+Example plot scripts live in `tools/plots/`. They write:
+- a **PNG** to `docs/assets/gallery/_`
+- a **YAML** sidecar with metadata (title, params, code path)
+> Tip: the first run may download data; use `--cache .fastf1-cache` for speed on subsequent runs.
+
+### Tyre strategy
+```bash
+python tools/plots/tyre_strategy.py \
+  --year 2025 \
+  --event "Italian Grand Prix" \
+  --cache .fastf1-cache
+```
+#### Common params
+- `--event` (e.g., "Monaco" or "Italian Grand Prix")
+- `--driver-order` = `results`|`alpha`|comma list (`VER,LEC,HAM`)
+- `--dpi`,`--title`,`--outdir`
+
+### DRS Effectiveness
+```bash
+python tools/plots/drs_effectiveness.py \
+  --year 2025 \
+  --gp "Italian Grand Prix" \
+  --session R \
+  --driver VER \
+  --cache .fastf1-cache
+```
+#### Common params
+- `--driver` (3-letter code), `--session` (default `R`)
+- `--n-points`,`--accel-threshold-kmh-s`,`--sustain-sec`
+- `--dpi`,`--title`,`--outdir`
+
+### Drivers' Championship Points
+```bash
+python tools/plots/driver_championship.py \
+  --year 2024 \
+  --include-sprints \
+  --color-variant secondary \
+  --min-total-points 0 \
+  --cache .fastf1-cache
+```
+#### Common params
+- `--include-sprints` (include sprint points)
+- `--color-variant`=`primary`|`secondary`
+- `--min-total-points`,`--dpi`,`--title`,`--outdir`
+
+## Update the Gallery page
+After generating/refreshing plots:
+```bash
+python tools/generate_gallery.py
+```
+This reads all YAML sidecars and **rewrites the cards** in `docs/gallery.md` between the `AUTO-GALLERY` markers.
+
+## Where to find outputs
+- Images: `docs/assets/gallery/*.png`
+- YAML sidecars: `docs/assets/gallery/*.yml`
+- Docs preview: `mkdocs serve` → open http://127.0.0.1:8000
+
+## Programmatic Usage (quick examples)
+Short notebook/script examples that mirror the CLI outputs.
+1) Load a session & apply style
 ```python
-from fastf1_portfolio import load_session, apply_style
+from fastf1_portfolio import apply_style
+from fastf1_portfolio.session_loader import load_session
+
+apply_style()
+session = load_session(2024, "Monaco", "R", cache=".fastf1-cache")
+print(session.event["EventName"], session.name)  # e.g., "Monaco Grand Prix R"
+```
+2) Build a chart in Python (tyre strategy)
+```python
+from fastf1_portfolio.session_loader import load_session
+from fastf1_portfolio.charts.tyre_strategy import (
+    TyreStrategyParams, build_tyre_strategy
+)
+
+s = load_session(2025, "Italian Grand Prix", "R", cache=".fastf1-cache")
+params = TyreStrategyParams(driver_order=["VER", "LEC", "HAM"], dpi=220)
+fig, ax = build_tyre_strategy(
+    s,
+    params=params,
+    out_path="docs/assets/gallery/italian_grand_prix_2025_tyre_strategy.png"
+)
 ```
 
----
+## Troubleshooting & tips
+- **Cache:** pass `--cache .fastf1-cache` (or another path). Delete the folder to refresh data.
+- **Gallery not updating:** re-run `python tools/generate_gallery.py` after creating PNG/YAML.
+- **Docs:** `mkdocs serve` to preview, `mkdocs build` for the static site.
+- **Style:** call `apply_style()` before plotting in custom code.
 
-> Built on [FastF1](https://docs.fastf1.dev/).
+> Built on [FastF1](https://docs.fastf1.dev/)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Analyses and reusable helpers built on [FastF1](https://docs.fastf1.dev/) to sho
     - [Tyre Strategy](#tyre-strategy)
     - [DRS Effectiveness](#drs-effectiveness)
     - [Drivers' Phampionship Points](#drivers-championship-points)
+    - [Common Flags](#common-flags)
     - [Update the Gallery Page](#update-the-gallery-page)
     - [Where to find Outputs](#where-to-find-outputs)
 - [Programmatic Usage (quick examples)](#programmatic-usage-quick-examples)
@@ -127,10 +128,9 @@ python tools/plots/tyre_strategy.py \
   --event "Italian Grand Prix" \
   --cache .fastf1-cache
 ```
-#### Common params
+#### Plot Params
 - `--event` (e.g., "Monaco" or "Italian Grand Prix")
 - `--driver-order` = `results`|`alpha`|comma list (`VER,LEC,HAM`)
-- `--dpi`,`--title`,`--outdir`
 
 ### DRS Effectiveness
 ```bash
@@ -141,10 +141,9 @@ python tools/plots/drs_effectiveness.py \
   --driver VER \
   --cache .fastf1-cache
 ```
-#### Common params
+#### Plot Params
 - `--driver` (3-letter code), `--session` (default `R`)
 - `--n-points`,`--accel-threshold-kmh-s`,`--sustain-sec`
-- `--dpi`,`--title`,`--outdir`
 
 ### Drivers' Championship Points
 ```bash
@@ -155,10 +154,16 @@ python tools/plots/driver_championship.py \
   --min-total-points 0 \
   --cache .fastf1-cache
 ```
-#### Common params
+#### Plot Params
 - `--include-sprints` (include sprint points)
 - `--color-variant`=`primary`|`secondary`
-- `--min-total-points`,`--dpi`,`--title`,`--outdir`
+- `--min-total-points`
+
+### Common Flags
+- `--cache PATH`              # FastF1 cache dir
+- `--outdir DIR`              # Output for PNG/YAML
+- `--title TEXT`              # Override default title
+- `--dpi INT`                 # image DPI
 
 ## Update the Gallery Page
 After generating/refreshing plots:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 [![CI](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/ci.yml)
 [![Docs](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/docs.yml/badge.svg)](https://ksherr0.github.io/fastf1_portfolio/)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fksherr0.github.io%2Ffastf1_portfolio%2F)](https://ksherr0.github.io/fastf1_portfolio/)
+[![Made with: Material for MkDocs](https://img.shields.io/badge/docs-Material%20for%20MkDocs-000?logo=materialformkdocs)](https://squidfunk.github.io/mkdocs-material/)
+
+![Python](https://img.shields.io/badge/python-3.13%2B-blue)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Lint: ruff](https://img.shields.io/badge/lint-ruff-0055A4?logo=ruff&logoColor=white)](https://github.com/astral-sh/ruff)
+[![Tests: pytest](https://img.shields.io/badge/tests-pytest-0A9EDC?logo=pytest&logoColor=white)](https://docs.pytest.org/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
+
 
 Analyses and reusable helpers built on [FastF1](https://docs.fastf1.dev/) to showcase race strategy, telemetry, and season-long insights.
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,64 @@
 Analyses and reusable helpers built on [FastF1](https://docs.fastf1.dev/) to showcase race strategy, telemetry, and season-long insights.
 
 - [CI](https://github.com/ksherr0/fastf1_portfolio/actions/workflows/ci.yml)
-- [Docs (Github Pages)](https://ksherr0.github.io/fastf1_portfolio/)
+- [Docs (GitHub Pages)](https://ksherr0.github.io/fastf1_portfolio/)
 
 ## Table of Contents:
-- [Docs overview (Github Pages)](#docs-overview-github-pages)
+- [Quickstart](#quickstart)
+- [Repository Directory](#repository-directory)
+- [Docs Overview (GitHub Pages)](#docs-overview-github-pages)
 - [Requirements](#requirements)
 - [Install](#install)
 - [Pre-checks (what CI runs)](#pre-checks-what-ci-runs)
-- [Generate the plots (CLI)](#generate-the-plots-cli)
+- [Generate the Plots (CLI)](#generate-the-plots-cli)
     - [Tyre Strategy](#tyre-strategy)
     - [DRS Effectiveness](#drs-effectiveness)
-    - [Drivers' championship points](#drivers-championship-points)
-    - [Update the Gallery page](#update-the-gallery-page)
-    - [Where to find outputs](#where-to-find-outputs)
-- [Programmatic usage (quick examples)](#programmatic-usage-quick-examples)
-- [Troubleshooting & tips](#troubleshooting--tips)
+    - [Drivers' Phampionship Points](#drivers-championship-points)
+    - [Update the Gallery Page](#update-the-gallery-page)
+    - [Where to find Outputs](#where-to-find-outputs)
+- [Programmatic Usage (quick examples)](#programmatic-usage-quick-examples)
+- [Troubleshooting & Tips](#troubleshooting--tips)
 
-## Docs overview (Github Pages)
+## Quickstart
+```bash
+# 1) Clone & install (Python 3.13+)
+git clone https://github.com/ksherr0/fastf1_portfolio.git
+cd fastf1_portfolio
+
+# 2) Create Virual Environment (optional, but recommended)
+python -m venv .venv
+
+# Windows (PowerShell)
+.venv\Scripts\Activate 
+# macOS/Linux
+source .venv/bin/activate
+
+# 3) Install project dependencies
+pip install -e . # run pip install -e .[dev] for optional dependencies
+
+# 4) Generate a plot (writes PNG+YAML to docs/assets/gallery/)
+python tools/plots/tyre_strategy.py --year 2025 --event "Italian Grand Prix" --cache .fastf1-cache
+
+# 5) Update gallery and preview docs
+python tools/generate_gallery.py
+mkdocs serve  # open http://127.0.0.1:8000
+```
+
+## Repository Directory
+```text
+fastf1_portfolio/
+├─ src/fastf1_portfolio/           # library code
+│  ├─ charts/                      # chart builders (Matplotlib)
+│  ├─ plotting.py                  # style/colors/helpers
+│  └─ session_loader.py            # load_session()
+├─ tools/
+│  ├─ plots/                       # CLI plot scripts (3 examples)
+│  └─ generate_gallery.py          # rebuilds docs/gallery.md from YAML sidecars
+├─ docs/                           # GitHub Pages (MkDocs)
+└─ tests/                          # minimal tests used by CI
+```
+
+## Docs Overview (GitHub Pages)
 If you’re not sure where something lives in the docs, use this map:
 - **Home (Quickstart):** install, run 1-2 plots, rebuild gallery, preview site
     - https://ksherr0.github.io/fastf1_portfolio/
@@ -54,8 +95,12 @@ If you’re not sure where something lives in the docs, use this map:
 ```bash
 git clone https://github.com/ksherr0/fastf1_portfolio.git
 cd fastf1_portfolio
+python -m venv .venv
 
-python -m venv .venv && source .venv\Scripts\activate  # Linux: .venv/bin/activate
+# Windows (PowerShell)
+.venv\Scripts\Activate 
+# macOS/Linux
+source .venv/bin/activate
 
 # editable install with dev extras (linters, tests, docs)
 pip install -e .[dev]
@@ -69,15 +114,13 @@ black --check .
 pytest -q
 ```
 
-<div style="page-break-after: always"></div>
-
-## Generate the plots (CLI)
+## Generate the Plots (CLI)
 Example plot scripts live in `tools/plots/`. They write:
-- a **PNG** to `docs/assets/gallery/_`
+- a **PNG** to `docs/assets/gallery/`
 - a **YAML** sidecar with metadata (title, params, code path)
 > Tip: the first run may download data; use `--cache .fastf1-cache` for speed on subsequent runs.
 
-### Tyre strategy
+### Tyre Strategy
 ```bash
 python tools/plots/tyre_strategy.py \
   --year 2025 \
@@ -117,14 +160,14 @@ python tools/plots/driver_championship.py \
 - `--color-variant`=`primary`|`secondary`
 - `--min-total-points`,`--dpi`,`--title`,`--outdir`
 
-## Update the Gallery page
+## Update the Gallery Page
 After generating/refreshing plots:
 ```bash
 python tools/generate_gallery.py
 ```
 This reads all YAML sidecars and **rewrites the cards** in `docs/gallery.md` between the `AUTO-GALLERY` markers.
 
-## Where to find outputs
+## Where to Find Outputs
 - Images: `docs/assets/gallery/*.png`
 - YAML sidecars: `docs/assets/gallery/*.yml`
 - Docs preview: `mkdocs serve` → open http://127.0.0.1:8000
@@ -156,7 +199,7 @@ fig, ax = build_tyre_strategy(
 )
 ```
 
-## Troubleshooting & tips
+## Troubleshooting & Tips
 - **Cache:** pass `--cache .fastf1-cache` (or another path). Delete the folder to refresh data.
 - **Gallery not updating:** re-run `python tools/generate_gallery.py` after creating PNG/YAML.
 - **Docs:** `mkdocs serve` to preview, `mkdocs build` for the static site.

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -11,7 +11,7 @@ and a YAML sidecar under `docs/assets/gallery/`.
   [![2024 Drivers' Championship – Cumulative points](assets/gallery/2024_drivers_championship_points.png){ loading=lazy }](assets/gallery/2024_drivers_championship_points.png){ .glightbox }
   _Total points by race (lines per driver)_
 
-  `Source:` [tools/plots/driver_championship.py](https://github.com/ksherr0/fastf1_portfolio/blob/feat/update-mkdocs/tools/plots/driver_championship.py)  
+  `Source:` [tools/plots/driver_championship.py](https://github.com/ksherr0/fastf1_portfolio/blob/chore/update-documentation/tools/plots/driver_championship.py)  
   `Params:` `year=2024, include_sprints=True, color_variant=secondary, min_total_points=0.0, dpi=220`
 
 - :material-chart-bar: **2025 Italian Grand Prix – DRS effect on main straight (VER)**
@@ -19,7 +19,7 @@ and a YAML sidecar under `docs/assets/gallery/`.
   [![2025 Italian Grand Prix – DRS effect on main straight (VER)](assets/gallery/italian_grand_prix_2025_drs_effect_VER.png){ loading=lazy }](assets/gallery/italian_grand_prix_2025_drs_effect_VER.png){ .glightbox }
   _Median speed traces along main straight (DRS ON/OFF)_
 
-  `Source:` [tools/plots/drs_effectiveness.py](https://github.com/ksherr0/fastf1_portfolio/blob/feat/update-mkdocs/tools/plots/drs_effectiveness.py)  
+  `Source:` [tools/plots/drs_effectiveness.py](https://github.com/ksherr0/fastf1_portfolio/blob/chore/update-documentation/tools/plots/drs_effectiveness.py)  
   `Params:` `year=2025, gp=Italian Grand Prix, session=R, driver=VER, n_points=200, accel_threshold_kmh_s=-8.0, sustain_sec=0.3`
 
 - :material-chart-bar: **2025 Italian Grand Prix – Tyre Strategy**
@@ -27,7 +27,7 @@ and a YAML sidecar under `docs/assets/gallery/`.
   [![2025 Italian Grand Prix – Tyre Strategy](assets/gallery/italian_grand_prix_2025_tyre_strategy.png){ loading=lazy }](assets/gallery/italian_grand_prix_2025_tyre_strategy.png){ .glightbox }
   _Stints and compounds by driver_
 
-  `Source:` [tools/plots/tyre_strategy.py](https://github.com/ksherr0/fastf1_portfolio/blob/feat/update-mkdocs/tools/plots/tyre_strategy.py)  
+  `Source:` [tools/plots/tyre_strategy.py](https://github.com/ksherr0/fastf1_portfolio/blob/chore/update-documentation/tools/plots/tyre_strategy.py)  
   `Params:` `driver_order=results, bar_height=0.6, bar_gap=0.35, annotate_compound=True, dpi=220`
 
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
   "numpy>=1.24",
   "scipy>=1.10",
   "tqdm>=4.65",
+  "PyYAML>=6.0.2",
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.5.0",
+  "mkdocstrings[python]>=0.24.0",
+  "mkdocs-glightbox>=0.3.7",
 ]
 
 [project.optional-dependencies]
@@ -27,12 +32,7 @@ dev = [
   "black>=24.3.0",
   "pre-commit>=3.6.0",
   "nbstripout>=0.7.1",
-  "mkdocs>=1.6",
-  "mkdocs-material>=9.5.0",
-  "mkdocstrings[python]>=0.24.0",
-  "mkdocs-glightbox>=0.3.7",
   "pymdown-extensions>=10.8",
-  "PyYAML>=6.0.2",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Overhaul README.md
- Add Quickstart (clone → install → run a plot → rebuild gallery → preview docs).
- Add Docs overview/map linking to Home, Gallery, How it works, API pages, and Reference.
- Clarify Install (Python 3.13+) and Pre-checks (ruff, black, pytest).
- Document CLI commands for all three plots (tyre strategy, DRS effectiveness, drivers’ championship) with key params.
- Add Programmatic examples (load a session, build a chart).
- Explain gallery refresh (tools/generate_gallery.py) and where outputs live (docs/assets/gallery/).
- Minor copy/path fixes and consistency (venv commands, GitHub capitalization).

Update pyproject.toml
- Move mkdocs dependencies to required from optional
- Move pyYAML dependency to required from optional

Update .pre-commit-config.yaml
- Add pre-push pytest check

