### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 ﻿name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/ksherr0/fastf1_portfolio/security/code-scanning/1](https://github.com/ksherr0/fastf1_portfolio/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to the workflow file. Since the job only runs tests and linters and does not need to write to the repository or interact with other resources, the minimal permission required is `contents: read`. Add the following block at the top level of the workflow file (after the `name:` and before `on:`), so that it applies to all jobs in the workflow. No additional packages or code changes are needed beyond this edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
